### PR TITLE
[MRG] Do not introspect arbitrary objects by default

### DIFF
--- a/whatami/plugins.py
+++ b/whatami/plugins.py
@@ -96,12 +96,14 @@ def function_plugin(what, v):
 
 # --- "Capture all" plugins
 
-def anyobject0x_plugin(what, v):
+def anyobject0x_plugin(what, v, deep=False):
     """An object without proper representation, try a best effort."""
     if ' at 0x' in str(v):
-        what = What(v.__class__.__name__, config_dict_for_object(v), what.non_id_keys)
+        if deep:
+            what = What(v.__class__.__name__, config_dict_for_object(v), what.non_id_keys)
+        else:
+            what = What(v.__class__.__name__, {})
         return what.id()
-    return None
 
 
 def anyobject_plugin(_, v):

--- a/whatami/plugins.py
+++ b/whatami/plugins.py
@@ -19,7 +19,6 @@ def what_plugin(_, v):
     """Deals with What objects."""
     if isinstance(v, What):
         return v.id()
-    return None
 
 
 def whatable_plugin(_, v):
@@ -47,32 +46,27 @@ def dict_plugin(what, v):
     if isinstance(v, dict):
         kvs = sorted('%s:%s' % (what.build_string(k), what.build_string(v)) for k, v in v.items())
         return '{%s}' % ','.join(kvs)
-    return None
 
 
 def set_plugin(what, v):
     if isinstance(v, set):
         elements = sorted(map(what.build_string, v))
         return '{%s}' % ','.join(elements) if len(elements) > 0 else 'set()'
-    return None
 
 
 def list_plugin(what, v):
     if isinstance(v, list):
         return '[%s]' % ','.join(map(what.build_string, v))
-    return None
 
 
 def tuple_plugin(what, v):
     if isinstance(v, tuple):
         return '(%s)' % ','.join(map(what.build_string, v))
-    return None
 
 
 def string_plugin(_, v):
     if isinstance(v, (str, str3)):
         return '\'%s\'' % v
-    return None
 
 
 # --- Function plugins
@@ -86,7 +80,6 @@ def partial_plugin(what, v):
     if isinstance(v, partial):
         name, keywords = callable2call(v)
         return What(name, keywords, what.non_id_keys).id()
-    return None
 
 
 def function_plugin(what, v):

--- a/whatami/tests/fixtures.py
+++ b/whatami/tests/fixtures.py
@@ -85,8 +85,15 @@ def array(request):
 
 def pandas_skip(test):  # pragma: no cover
     """Skips a test if the pandas plugin is not available."""
+    # Check libraries are present
     if not (has_pandas() and has_joblib()):
         return pytest.mark.skipif(test, reason='the pandas plugin requires both pandas and joblib')
+    # Check library versions
+    from ..plugins import pd
+    from distutils.version import LooseVersion
+    minor = LooseVersion(pd.__version__).version[1]
+    if minor not in (16, 17):
+        return pytest.mark.skipif(test, reason='these tests do not support pandas version %s' % pd.__version__)
     return test
 
 
@@ -95,21 +102,39 @@ def pandas_skip(test):  # pragma: no cover
 def df(request):
     """Hardcodes hashes, so we can detect hashing changes in joblib."""
     from ..plugins import pd, np
+    from distutils.version import LooseVersion
     adjacency = np.array([[1, 0, 1], [0, 1, 0], [1, 0, 1]])
-    dfs = {
-        'df1': (pd.DataFrame(data=adjacency, columns=['x', 'y', 'z']),
-                'fc5d5b43464052efbcd9e88dc0be4afd', '62171fe1114d5d961742dd95e6af37d7'),
-        'df2': (pd.DataFrame(data=adjacency, columns=['xx', 'yy', 'zz']),
-                'fe226e22261ff56d4cf019aa64942050', '139261e54b3ac2f2e39da6d497f6d0fd'),
-        'df3': (pd.DataFrame(data=adjacency.T, columns=['x', 'y', 'z']),
-                'f3d11416b1d5cb5da7753991941beb0d', 'fcd984c10ea9379faee471eedafee77b'),
-        'df4': (pd.DataFrame(data=adjacency, columns=['x', 'y', 'z'], index=['r1', 'r2', 'r3']),
-                '95fc40cb4635424c7ef1577d13183afa', 'c5234b1a362ef13c9c12b7b7444b8c85'),
-        's1': (pd.Series(data=adjacency.ravel()),
-               'e37122dc5f6320e9f12b413631056443', 'ee9729300f29a6917f30aa9e612ec67c'),
-        's2': (pd.Series(data=adjacency.ravel(), index=list(range(len(adjacency.ravel()))))[::-1],
-               'c0f4565b063599c6075ec6108cbca344', '74e14992d8587454d561b3194d11a984'),
-    }
+    dfs = {}
+    if LooseVersion('0.16') <= LooseVersion(pd.__version__) < LooseVersion('0.17'):
+        dfs = {
+            'df1': (pd.DataFrame(data=adjacency, columns=['x', 'y', 'z']),
+                    'fc5d5b43464052efbcd9e88dc0be4afd', '62171fe1114d5d961742dd95e6af37d7'),
+            'df2': (pd.DataFrame(data=adjacency, columns=['xx', 'yy', 'zz']),
+                    'fe226e22261ff56d4cf019aa64942050', '139261e54b3ac2f2e39da6d497f6d0fd'),
+            'df3': (pd.DataFrame(data=adjacency.T, columns=['x', 'y', 'z']),
+                    'f3d11416b1d5cb5da7753991941beb0d', 'fcd984c10ea9379faee471eedafee77b'),
+            'df4': (pd.DataFrame(data=adjacency, columns=['x', 'y', 'z'], index=['r1', 'r2', 'r3']),
+                    '95fc40cb4635424c7ef1577d13183afa', 'c5234b1a362ef13c9c12b7b7444b8c85'),
+            's1': (pd.Series(data=adjacency.ravel()),
+                   'e37122dc5f6320e9f12b413631056443', 'ee9729300f29a6917f30aa9e612ec67c'),
+            's2': (pd.Series(data=adjacency.ravel(), index=list(range(len(adjacency.ravel()))))[::-1],
+                   'c0f4565b063599c6075ec6108cbca344', '74e14992d8587454d561b3194d11a984'),
+        }
+    elif LooseVersion('0.17') <= LooseVersion(pd.__version__):
+        dfs = {
+            'df1': (pd.DataFrame(data=adjacency, columns=['x', 'y', 'z']),
+                    '4e3bd601694d810b122afcaa03dc8657', '4e170e720983e95acf9f3dc236aad281'),
+            'df2': (pd.DataFrame(data=adjacency, columns=['xx', 'yy', 'zz']),
+                    'bed8e94e953d1a69b6b10f122db9d768', 'd37e44c3ea7562be9256435ec925080a'),
+            'df3': (pd.DataFrame(data=adjacency.T, columns=['x', 'y', 'z']),
+                    'b5a2fa63a034eff697e95eb4f849ba38', 'f5bf82a7647a0789b1714e503cad7d7a'),
+            'df4': (pd.DataFrame(data=adjacency, columns=['x', 'y', 'z'], index=['r1', 'r2', 'r3']),
+                    '6a24c46e973fe74b208b13f74435b041', 'b7747e3d4bbd4477698037eb9d933282'),
+            's1': (pd.Series(data=adjacency.ravel()),
+                   'd5dc5e9943d1b74f604a99dd74e8d034', '6e62c2340b898886512176c20011fab6'),
+            's2': (pd.Series(data=adjacency.ravel(), index=list(range(len(adjacency.ravel()))))[::-1],
+                   'd8ec7deecaca6a0a42a2c9967e2beba6', '1f6fc6f831e48c59868f1e0157df79c5'),
+        }
     return dfs[request.param]
 
 

--- a/whatami/tests/test_whatable.py
+++ b/whatami/tests/test_whatable.py
@@ -77,6 +77,8 @@ def test_whatable_anyobject(c1):
         def __init__(self):
             self.param = 'yes'
     c1.p1 = RandomClass()
+    assert c1.what().id() == "C1(length=1,p1=RandomClass(),p2='bleh')"
+    c1.p1 = whatable(RandomClass())
     assert c1.what().id() == "C1(length=1,p1=RandomClass(param='yes'),p2='bleh')"
 
 

--- a/whatami/tests/test_whatable.py
+++ b/whatami/tests/test_whatable.py
@@ -5,6 +5,7 @@ import pickle
 
 from ..what import is_whatable, What, trim_dict, config_dict_for_object
 from .fixtures import *
+from whatami.plugins import WhatamiPluginManager, anyobject0x_plugin, anyobject_plugin
 
 
 def test_whatable_decorator():
@@ -72,12 +73,20 @@ def test_whatable_builtins(c1):
 
 def test_whatable_anyobject(c1):
 
-    # Objects without proper representation
+    # Objects without proper representation - default
     class RandomClass(object):
         def __init__(self):
             self.param = 'yes'
     c1.p1 = RandomClass()
     assert c1.what().id() == "C1(length=1,p1=RandomClass(),p2='bleh')"
+
+    # Objects without proper representation - deep introspection
+    WhatamiPluginManager.drop(anyobject0x_plugin)
+    WhatamiPluginManager.insert(partial(anyobject0x_plugin, deep=True), before=anyobject_plugin)
+    assert c1.what().id() == "C1(length=1,p1=RandomClass(param='yes'),p2='bleh')"
+    WhatamiPluginManager.reset()
+
+    # Making the object whatable
     c1.p1 = whatable(RandomClass())
     assert c1.what().id() == "C1(length=1,p1=RandomClass(param='yes'),p2='bleh')"
 

--- a/whatami/what.py
+++ b/whatami/what.py
@@ -116,7 +116,7 @@ class What(object):
     def copy(self):
         """Returns a copy of this whatable object.
 
-        N.B. The configuration dictionary is copy is shallow;
+        N.B. The configuration dictionary copy is shallow;
         side-effects might happen if changes are made to mutable values.
         """
         return What(name=self.name, conf=self.conf.copy(), non_id_keys=self.non_id_keys)


### PR DESCRIPTION
Tackles #9.

Also highlighted the need for:

  - Cycles in the object graph should be handled to avoid giagantic stacktraces. A look at how pytest does it (probably capturing the relevant exception and simplifying the message) might be useful.

  - We need a proper way to create plugins contexts (although that is hard and dangerous given the library philosophy).

  - The need for proper documentation (in this case what whatami will do when finding an arbitrary, non-whatable object).